### PR TITLE
My take on improving README of code-d

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,17 @@ Also [available for Atom](https://github.com/Vild/atomize-d)!
 
 ## Installation
 
-**Easy Installation using the official [workspace-d-installer](https://github.com/Pure-D/workspace-d-installer)**
+### Dependencies:
 
-Make sure you install all components!
+Code-d needs its backend, [workspace-d](https://github.com/Pure-D/workspace-d). 
+Installing it will automatically detect or install the necessary D tools 
+([dcd](https://github.com/Hackerpilot/DCD), [dfmt](https://github.com/Hackerpilot/dfmt), [dscanner](https://github.com/Hackerpilot/Dscanner)).
 
-### Manual installation (if the installer doesn't work)
+### Automatic code-d installation
 
-[dcd](https://github.com/Hackerpilot/DCD),
-[dfmt](https://github.com/Hackerpilot/dfmt),
-[dscanner](https://github.com/Hackerpilot/Dscanner) and 
-[workspace-d](https://github.com/Pure-D/workspace-d)
+Open VS Code and install code-d extension the normal way.
+
+### Manual code-d installation (if the installer doesn't work)
 
 ```
 cd ~/.vscode/extensions/

--- a/README.md
+++ b/README.md
@@ -21,8 +21,14 @@ Installing it will automatically detect or install the necessary D tools
 
 ### Code-d installation
 
+This assumes [workspace-d](https://github.com/Pure-D/workspace-d) is already installed.
+
 * Automatic:
-  Open Visual Studio Code and install _code-d_ extension the normal way.
+  Open Visual Studio Code and install _code-d_ extension the normal way:
+
+  ```
+  ext install webfreak.code-d
+  ```
 
 * Manual (if the automatic way doesn't work)
 

--- a/README.md
+++ b/README.md
@@ -15,23 +15,24 @@ Also [available for Atom](https://github.com/Vild/atomize-d)!
 
 ### Dependencies:
 
-Code-d needs its backend, [workspace-d](https://github.com/Pure-D/workspace-d). 
+Code-d needs its backend, [workspace-d](https://github.com/Pure-D/workspace-d). Go there and follow the installation instructions.
 Installing it will automatically detect or install the necessary D tools 
 ([dcd](https://github.com/Hackerpilot/DCD), [dfmt](https://github.com/Hackerpilot/dfmt), [dscanner](https://github.com/Hackerpilot/Dscanner)).
 
-### Automatic code-d installation
+### Code-d installation
 
-Open VS Code and install code-d extension the normal way.
+* Automatic:
+  Open Visual Studio Code and install _code-d_ extension the normal way.
 
-### Manual code-d installation (if the installer doesn't work)
+* Manual (if the automatic way doesn't work)
 
-```
-cd ~/.vscode/extensions/
-git clone https://github.com/Pure-D/code-d.git
-cd code-d
-npm install
-node ./node_modules/vscode/bin/compile
-```
+    ```
+    cd ~/.vscode/extensions/
+    git clone https://github.com/Pure-D/code-d.git
+    cd code-d
+    npm install
+    node ./node_modules/vscode/bin/compile
+    ```
 
 ## License
 


### PR DESCRIPTION
There were multiple issues with the original readme:
* It referenced moved project workspace-d-installer
* The "Easy Installation ..." part suggested that it installed code-d, which it didn't.
* The "Manual installation" was not doing equivalent thing to the "Easy Installation ..." part.
* The "Manual installation" had different font size than "Easy Installation ..." and it wasn't clear why.
* The README worked to some extent, when displayed on VS Code marketplace, as there is additional information at the top about how to install code-d itself the easy way in the editor (ext install code-d). Actually, the additional bit is the most important bit. The readme wasn't as clear when read on the github page. Even on the marketplace, if someone misses the bit at the top (entirely possible if someone is new to VS Code), the original README below will confuse him. This change is intended to fix that.