### PR TITLE
Add Formatters to category list

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"Languages",
 		"Snippets",
 		"Linters",
+		"Formatters",
 		"Other"
 	],
 	"activationEvents": [


### PR DESCRIPTION
The Marketplace has introduce a new category called formatters for extensions that add formatting.