### PR TITLE
Fix broken installation on macOS

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -150,7 +150,11 @@ export function activate(context: vscode.ExtensionContext) {
 				var version = "";
 				ChildProcess.spawn(config().get(configName, defaultPath), ["--version"], { cwd: vscode.workspace.rootPath, env: env }).on("error", function (err) {
 					if (err && (<any>err).code == "ENOENT") {
-						if (fs.statSync(config().get(configName, "")).isDirectory()) {
+						var isDirectory = false;
+						try {
+							isDirectory = fs.statSync(config().get(configName, "")).isDirectory();
+						} catch (e) {}
+						if (isDirectory) {
 							vscode.window.showErrorMessage(name + " points to a directory", "Open User Settings").then(s => {
 								if (s == "Open User Settings")
 									vscode.commands.executeCommand("workbench.action.openGlobalSettings");

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -260,7 +260,7 @@ function spawnCommand(output: vscode.OutputChannel, cmd: string, args: string[],
 	});
 }
 
-export function compileDependency(cwd, name, gitPath, commands, callback, env) {
+export function compileDependency(cwd, name, gitURI, commands, callback, env) {
 	var output = vscode.window.createOutputChannel(name + " installation progress");
 	extensionContext.subscriptions.push(output);
 	output.show(true);
@@ -270,7 +270,7 @@ export function compileDependency(cwd, name, gitPath, commands, callback, env) {
 	};
 	var newCwd = path.join(cwd, name);
 	var startCompile = () => {
-		spawnCommand(output, gitPath(), ["clone", gitPath, name], { cwd: cwd, env: env }, (err) => {
+		spawnCommand(output, gitPath(), ["clone", "--recursive", gitURI, name], { cwd: cwd, env: env }, (err) => {
 			if (err !== 0)
 				return error(err);
 			async.eachSeries(commands, function (command, cb) {


### PR DESCRIPTION
On my macOS Sierra box I ran into several errors while trying to install workspace-d. First it complained that `gitPath` isn't a function. Then dub complained that libdparse was missing a package file like `dub.json`. And finally, after workspace-d installed successfully, it errored while trying to check whether dscanner was installed. This PR fixes all those issues for me.