### PR TITLE
Accept uppercase letters A-Z in configuration names in dub.json

### DIFF
--- a/json-validation/dub.schema.json
+++ b/json-validation/dub.schema.json
@@ -7,6 +7,10 @@
             "type": "string",
             "pattern": "^[-a-z0-9_]+$"
         },
+        "configurationName": {
+            "type": "string",
+            "pattern": "^[-a-zA-Z0-9_]+$"
+        },
         "stringArray": {
             "type": "array",
             "items": {
@@ -300,8 +304,8 @@
                             {
                                 "properties": {
                                     "name": {
-                                        "$ref": "#/definitions/packageName",
-                                        "description": "Name of the package, used to uniquely identify the package. Must be comprised of only lower case ASCII alpha-numeric characters, \"-\" or \"_\"."
+                                        "$ref": "#/definitions/configurationName",
+                                        "description": "Name of the configuration, used to uniquely identify the configuration. Must be comprised of ASCII alpha-numeric characters, \"-\" or \"_\"."
                                     }
                                 }
                             },


### PR DESCRIPTION
This commit introduces acceptance of uppercase letters in configuration names.
Change pattern of "name" for configurations. It seems there is no actual constraint on this name in DUB, but we should as well keep some.