### PR TITLE
[Windows] Fix wrong dscanner.exe path

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -193,10 +193,7 @@ export function compileDScanner(env) {
 			process.platform == "win32" ? ["cmd.exe", ["/c", "build.bat"]] : ["make", []]
 		], function () {
 			var finalDestination: string;
-			if (process.platform == "win32")
-				finalDestination = path.join(outputFolder, "Dscanner", "dscanner.exe");
-			else
-				finalDestination = path.join(outputFolder, "Dscanner", "bin", "dscanner");
+			finalDestination = path.join(outputFolder, "Dscanner", "bin", "dscanner");
 
 			config().update("dscannerPath", finalDestination, true);
 			vscode.window.showInformationMessage("Dscanner successfully installed", "Reload").then((r) => {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -193,7 +193,10 @@ export function compileDScanner(env) {
 			process.platform == "win32" ? ["cmd.exe", ["/c", "build.bat"]] : ["make", []]
 		], function () {
 			var finalDestination: string;
-			finalDestination = path.join(outputFolder, "Dscanner", "bin", "dscanner");
+			if (process.platform == "win32")
+				finalDestination = path.join(outputFolder, "Dscanner", "bin", "dscanner.exe");
+			else
+				finalDestination = path.join(outputFolder, "Dscanner", "bin", "dscanner");
 
 			config().update("dscannerPath", finalDestination, true);
 			vscode.window.showInformationMessage("Dscanner successfully installed", "Reload").then((r) => {


### PR DESCRIPTION
Dscanner now(?) compiles to Dscanner\bin on Windows too.
 
![code-d_dscanner_windows-bug](https://user-images.githubusercontent.com/11427815/33916142-a55e5a2c-dfa7-11e7-9a05-82fa4033099a.png)

_[Warn! Didn't tested yet due to time but manually changing path works so... it should... i hope... For details or tests @WebFreak001 can me catch on Wild Discord too (under nick BrodatyNiedzwiedz)]_