### PR TITLE
Fixing Windows 10 DCD compilation

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -248,7 +248,7 @@ export function compileDCD(env) {
 			[gitPath(), ["submodule", "update", "--init", "--recursive"]]
 		];
 		if (process.platform == "win32") {
-			commands.push(["dub", ["build", "--config=client", "--arch=x86_mscoff"]], ["dub", ["build", "--config=server", "--arch=x86_mscoff"]]);
+			commands.push(["dub", ["build", "--config=client"]], ["dub", ["build", "--config=server"]]);
 		} else {
 			commands.push(["make", []]);
 		}


### PR DESCRIPTION
Removing the explicit --arch=x86_mscoff option for win32 platform build of DCD allows the compilation to complete successfully on my Windows 10. As the default destination of the dub build is not the bin subfolder, had to manually adapt the generated user settings. Will propose a change to DCD dub.json, keeping dub build in line with make and build.bat.