### PR TITLE
plug support of CCDB in code-d

### DIFF
--- a/package.json
+++ b/package.json
@@ -918,6 +918,12 @@
 						"order": 1,
 						"markdownDescription": "Array of workspace-relative (or absolute) folders to force start a project instance in."
 					},
+					"d.ccdbPath": {
+						"type": "string",
+						"scope": "resource",
+						"default": null,
+						"description": "Path to a Clang compilation database (aka. CCDB, aka. `compile_commands.json`) to use to lint this project"
+					},
 					"d.dmdPath": {
 						"type": "string",
 						"scope": "machine-overridable",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -222,7 +222,8 @@ async function startClient(context: vscode.ExtensionContext) {
 				vscode.workspace.createFileSystemWatcher("**/*.d"),
 				vscode.workspace.createFileSystemWatcher("**/dub.json"),
 				vscode.workspace.createFileSystemWatcher("**/dub.sdl"),
-				vscode.workspace.createFileSystemWatcher("**/profilegc.log")
+				vscode.workspace.createFileSystemWatcher("**/profilegc.log"),
+				vscode.workspace.createFileSystemWatcher("**/compile_commands.json"),
 			]
 		},
 		revealOutputChannelOn: RevealOutputChannelOn.Never,


### PR DESCRIPTION
enable CCDB in code-d:
 - new config key: `d.ccdbPath` for the path to `compile_commands.json`
 - add synchronization watcher on `compile_commands.json`

Works with https://github.com/Pure-D/serve-d/pull/271