### PR TITLE
Automatically continue doc comments

### DIFF
--- a/lang-configs/d.json
+++ b/lang-configs/d.json
@@ -86,5 +86,33 @@
 			"start": "^\\s*//\\s*dfmt\\s*off",
 			"end": "^\\s*//\\s*dfmt\\s*on"
 		}
-	}
+	},
+	"onEnterRules": [
+		{
+			"beforeText": "^\\s*\\/\\*\\*(?!\\/)([^\\*]|\\*(?!\\/))*$",
+			"afterText": "^\\s*\\*\/$",
+			"action": { "indent": "indentOutdent", "appendText": " * " }
+		},
+		{
+			"beforeText": "^\\s*\\/\\*\\*(?!\\/)([^\\*]|\\*(?!\\/))*$",
+			"action": { "indent": "none", "appendText": " * " }
+		},
+		{
+			"beforeText": "^(\\t|(\\ \\ ))*\\ \\*(\\ ([^\\*]|\\*(?!\\/))*)?$",
+			"action": { "indent": "none", "appendText": "* " }
+		},
+		{
+			"beforeText": "^\\s*\\/\\+\\+(?!\\/)([^\\+]|\\+(?!\\/))*$",
+			"afterText": "^\\s+\\+\/$",
+			"action": { "indent": "indentOutdent", "appendText": " + " }
+		},
+		{
+			"beforeText": "^\\s*\\/\\+\\+(?!\\/)([^\\+]|\\+(?!\\/))*$",
+			"action": { "indent": "none", "appendText": " + " }
+		},
+		{
+			"beforeText": "^(\\t|(\\ \\ ))*\\ \\+(\\ ([^\\+]|\\+(?!\\/))*)?$",
+			"action": { "indent": "none", "appendText": "+ " }
+		},
+	]
 }


### PR DESCRIPTION
Fixes #407.

The rules were just taken and adjusted from https://github.com/PowerShell/vscode-powershell/blob/43c8bff8bd316684fb4bc82cdbed36ceb7988904/src/extension.ts#L80-L114.

`///`-comments are not included but could easily be added in if needed:

```json
{
	"beforeText": "^\\s*\\/\\/\\/\\s*[^\\s]+$",
	"action": { "indent": "none", "appendText": "/// " }
}
```